### PR TITLE
Allow class_name selector updates and persist config

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,12 +4,18 @@ import os
 from typing import List, Optional
 from copy import deepcopy
 
-from config import DEFAULT_SCRAPER_CONFIG
-from utils.logging import setup_logging
+try:
+    from .config import DEFAULT_SCRAPER_CONFIG
+except ImportError:  # pragma: no cover
+    from config import DEFAULT_SCRAPER_CONFIG
+try:
+    from .utils.logging import setup_logging
+except ImportError:  # pragma: no cover
+    from utils.logging import setup_logging
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 # --- Configuration ---
 LOG_FILE = "priceza_scraper.log"
@@ -53,8 +59,9 @@ app.add_middleware(
 
 
 class SelectorDetail(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     tag: Optional[str] = None
-    class_name: Optional[str] = Field(None, alias="class") # Use alias for 'class' keyword
+    class_name: Optional[str] = Field(None, alias="class")  # Use alias for 'class' keyword
     id: Optional[str] = None
     attrs: Optional[dict] = None
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,5 @@ selenium==4.35.0
 beautifulsoup4==4.13.5
 python-multipart==0.0.20
 apscheduler==3.11.0
+httpx==0.27.2
+pytest==8.3.3

--- a/backend/test_scraper_config.py
+++ b/backend/test_scraper_config.py
@@ -1,0 +1,25 @@
+import json
+from copy import deepcopy
+from fastapi.testclient import TestClient
+from backend import main
+from backend.config import DEFAULT_SCRAPER_CONFIG
+
+def test_post_scraper_config_persists_class(tmp_path, monkeypatch):
+    temp_dir = tmp_path
+    cfg_file = temp_dir / "scraper_config.json"
+    monkeypatch.setattr(main, "DATA_DIR", str(temp_dir))
+    monkeypatch.setattr(main, "SCRAPER_CONFIG_FILE", str(cfg_file))
+
+    client = TestClient(main.app)
+
+    payload = deepcopy(DEFAULT_SCRAPER_CONFIG)
+    for sel, detail in payload["selectors"].items():
+        if "class" in detail:
+            detail["class_name"] = detail.pop("class")
+
+    response = client.post("/api/scraper_config", json=payload)
+    assert response.status_code == 200
+
+    saved = json.loads(cfg_file.read_text())
+    assert saved["selectors"]["load_more_button"]["class"] == "hotdeal-tab__load-more__btn"
+    assert "class_name" not in saved["selectors"]["load_more_button"]

--- a/frontend/src/ScraperCriteria.js
+++ b/frontend/src/ScraperCriteria.js
@@ -55,7 +55,7 @@ const ScraperCriteria = () => {
                 json_keys: values.json_keys,
             };
 
-            // Parse attrs JSON string back to object
+            // Parse attrs JSON string back to object and rename class_name -> class
             for (const key in configToSend.selectors) {
                 const selector = configToSend.selectors[key];
                 if (selector.attrs && typeof selector.attrs === 'string') {
@@ -67,7 +67,12 @@ const ScraperCriteria = () => {
                         return; // Stop submission
                     }
                 }
+                if (Object.prototype.hasOwnProperty.call(selector, 'class_name')) {
+                    selector.class = selector.class_name;
+                    delete selector.class_name;
+                }
             }
+
             await axios.post(`${API_BASE_URL}/api/scraper_config`, configToSend);
             message.success('Scraper configuration updated successfully!');
         } catch (error) {


### PR DESCRIPTION
## Summary
- Map `class_name` back to `class` before saving scraper criteria
- Accept `class_name` fields in backend via `populate_by_name`
- Add test ensuring selector classes persist in saved config

## Testing
- `pytest`
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token in axios)*

------
https://chatgpt.com/codex/tasks/task_e_68ba386f83c0832ab70bf97e5ad856a9