### PR TITLE
Allow additional frontend origin for backend CORS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./backend:/app
     environment:
-      - ALLOWED_ORIGINS=http://localhost:3000,http://frontend:3000
+      - ALLOWED_ORIGINS=http://localhost:3000,http://frontend:3000,http://81.17.100.56:3000
 
   scraper_runner:
     build: ./backend


### PR DESCRIPTION
## Summary
- permit frontend requests from 81.17.100.56:3000 in backend CORS config

## Testing
- `pytest`
- `curl -i -H "Origin: http://81.17.100.56:3000" http://localhost:8001/`
- `docker-compose down && docker-compose up --build -d` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba41182824832a8a4456c417ad28bd