### PR TITLE
Disable credentials for CORS wildcard

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -42,11 +42,17 @@ if origins_env:
     origins = [origin.strip() for origin in origins_env.split(",") if origin.strip()]
 else:
     origins = ["*"]
+allow_credentials = True
+if origins == ["*"]:
+    allow_credentials = False
+    logging.warning(
+        "ALLOWED_ORIGINS not set; allowing all origins without credentials."
+    )
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
-    allow_credentials=True,
+    allow_credentials=allow_credentials,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
- disable CORS credentials when ALLOWED_ORIGINS wildcard used
- log warning if using wildcard origins

## Testing
- `pytest -q`
- `python -m uvicorn backend.main:app --port 8000` (manual)
- `curl -I -H "Origin: http://example.com" http://127.0.0.1:8000/openapi.json`


------
https://chatgpt.com/codex/tasks/task_e_68ba435d2654832a97efb4f6a695a072