### PR TITLE
Configure frontend proxy and use relative API calls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - ./backend:/app
     environment:
       - ALLOWED_ORIGINS=http://localhost:3000,http://frontend:3000,http://81.17.100.56:3000
+    networks:
+      - backend_net
 
   scraper_runner:
     build: ./backend
@@ -19,6 +21,8 @@ services:
     depends_on:
       - backend_api # Scraper might need the API to be up, or at least the data directory
     restart: on-failure # Ensure scraper restarts if it crashes
+    networks:
+      - backend_net
 
   frontend:
     build: ./frontend
@@ -26,7 +30,11 @@ services:
       - "3000:3000"
     volumes:
       - ./frontend:/app # Mount for development, remove for production if not needed
-    environment:
-      - REACT_APP_API_BASE_URL=http://81.17.100.56:8000
+      - ./frontend/nginx.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       - backend_api # Frontend depends on backend API
+    networks:
+      - backend_net
+
+networks:
+  backend_net:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,4 +8,11 @@ server {
   location / {
     try_files $uri $uri/ /index.html;
   }
+
+  location /api/ {
+    proxy_pass http://backend_api:8000/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 import 'antd/dist/reset.css';
 import { Routes, Route } from 'react-router-dom';
 import ScraperCriteria from './ScraperCriteria';
@@ -23,8 +22,6 @@ import { SyncOutlined, ShoppingCartOutlined, CopyOutlined } from '@ant-design/ic
 const { Header, Content, Footer } = Layout;
 const { Title, Text, Paragraph } = Typography;
 
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
-const API_URL = `${API_BASE_URL}/api/deals`;
 
 // Custom Logo Component
 const AppLogo = () => (
@@ -50,14 +47,23 @@ const App = () => {
     setLoading(true);
     setError(null);
     try {
-      const response = await axios.get(API_URL);
-      const statusResponse = await axios.get(`${API_BASE_URL}/api/scraper_status`);
-      setIsScraping(statusResponse.data.is_scraping);
-      const products = response.data.products || [];
+      const response = await fetch('/api/deals');
+      if (!response.ok) {
+        throw new Error('Failed to fetch deals');
+      }
+      const data = await response.json();
+
+      const statusResponse = await fetch('/api/scraper_status');
+      if (statusResponse.ok) {
+        const statusData = await statusResponse.json();
+        setIsScraping(statusData.is_scraping);
+      }
+
+      const products = data.products || [];
       setDeals(products);
 
-      if (response.data.timestamp) {
-        const formattedDate = new Date(response.data.timestamp).toLocaleString();
+      if (data.timestamp) {
+        const formattedDate = new Date(data.timestamp).toLocaleString();
         setLastUpdated(formattedDate);
       }
 

--- a/frontend/src/ScraperCriteria.js
+++ b/frontend/src/ScraperCriteria.js
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { Form, Input, Button, Typography, message, Card, Row, Col } from 'antd';
-import axios from 'axios';
 
 const { Title, Text } = Typography;
 const { TextArea } = Input;
 
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
 
 const ScraperCriteria = () => {
     const [form] = Form.useForm();
@@ -15,8 +13,11 @@ const ScraperCriteria = () => {
         const fetchConfig = async () => {
             setLoading(true);
             try {
-                const response = await axios.get(`${API_BASE_URL}/api/scraper_config`);
-                const config = response.data;
+                const response = await fetch('/api/scraper_config');
+                if (!response.ok) {
+                    throw new Error('Failed to fetch config');
+                }
+                const config = await response.json();
                 // Transform 'class' to 'class_name' for form fields
                 const transformedSelectors = {};
                 for (const key in config.selectors) {
@@ -73,7 +74,13 @@ const ScraperCriteria = () => {
                 }
             }
 
-            await axios.post(`${API_BASE_URL}/api/scraper_config`, configToSend);
+            await fetch('/api/scraper_config', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(configToSend),
+            });
             message.success('Scraper configuration updated successfully!');
         } catch (error) {
             message.error('Failed to update scraper configuration.');


### PR DESCRIPTION
## Summary
- Add Nginx proxy configuration for `/api/` requests
- Mount Nginx config and share network with backend in Compose
- Fetch backend APIs via relative paths in React components

## Testing
- `pytest`
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*
- `docker compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7442f0dc832a9d741611b5f801b5