### PR TITLE
fix: preserve api prefix in nginx proxy

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,4 +8,8 @@ server {
   location / {
     try_files $uri $uri/ /index.html;
   }
+
+  location /api/ {
+    proxy_pass http://backend_api:8000;
+  }
 }


### PR DESCRIPTION
## Summary
- preserve `/api` prefix by removing trailing slash from frontend proxy_pass

## Testing
- `docker compose up --build -d` *(fails: command not found)*
- `curl -I http://localhost:3000/api/deals` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68ba768d66b0832ab3607f9d4ffca733