### PR TITLE
Guard database connection on missing env var

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,11 +1,12 @@
 import os
 import psycopg2
-import json
 import logging
 
 DATABASE_URL = os.environ.get("DATABASE_URL")
 
 def get_db_connection():
+    if not DATABASE_URL:
+        raise RuntimeError("DATABASE_URL environment variable is not set")
     conn = psycopg2.connect(DATABASE_URL)
     return conn
 


### PR DESCRIPTION
## Summary
- remove unused json import
- raise helpful error if DATABASE_URL is missing

## Testing
- `PYTHONPATH=backend pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baddcb8db8832ab7046855eeda202a