### PR TITLE
feat: reposition download button and add copy title

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -63,10 +63,10 @@ const App = () => {
 
   const handleDownload = async (cardRef) => {
     if (cardRef.current) {
-      const downloadButton = cardRef.current.parentElement.querySelector('.download-button');
-      if (downloadButton) {
-        downloadButton.style.display = 'none';
-      }
+      const actionButtons = cardRef.current.parentElement.querySelectorAll('.action-button');
+      actionButtons.forEach((btn) => {
+        btn.style.display = 'none';
+      });
 
       const canvas = await html2canvas(cardRef.current, {
         backgroundColor: null,
@@ -75,9 +75,9 @@ const App = () => {
         scale: 2,
       });
 
-      if (downloadButton) {
-        downloadButton.style.display = 'block';
-      }
+      actionButtons.forEach((btn) => {
+        btn.style.display = 'block';
+      });
 
       canvas.toBlob((blob) => {
         const url = URL.createObjectURL(blob);

--- a/frontend/src/components/FacebookCard.js
+++ b/frontend/src/components/FacebookCard.js
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
-import { Row, Col, Button, Tag, Typography, Space } from 'antd';
+import { Row, Col, Button, Tag, Typography, Space, message } from 'antd';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
-import { DownloadOutlined, FacebookOutlined, ShoppingCartOutlined, StarFilled } from '@ant-design/icons';
+import { DownloadOutlined, FacebookOutlined, ShoppingCartOutlined, StarFilled, CopyOutlined } from '@ant-design/icons';
 import { getStoreColor } from '../config/storeColors';
 
 const { Title, Text } = Typography;
@@ -10,12 +10,21 @@ const FacebookCard = ({ product, onDownload, calculateSavings }) => {
   const cardRef = useRef(null);
   return (
     <div style={{ position: 'relative' }}>
-      <Button
-        className="download-button"
-        icon={<DownloadOutlined />}
-        onClick={() => onDownload(cardRef)}
-        style={{ position: 'absolute', top: '24px', right: '-50px', zIndex: 2 }}
-      />
+      <div style={{ position: 'absolute', top: '24px', right: '24px', display: 'flex', gap: '8px', zIndex: 2 }}>
+        <Button
+          className="action-button copy-button"
+          icon={<CopyOutlined />}
+          onClick={() => {
+            navigator.clipboard.writeText(product.title);
+            message.success('Copied title');
+          }}
+        />
+        <Button
+          className="action-button download-button"
+          icon={<DownloadOutlined />}
+          onClick={() => onDownload(cardRef)}
+        />
+      </div>
       <div ref={cardRef} style={{ width: '1200px', height: '630px', background: 'white', borderRadius: '24px', boxShadow: '0 10px 30px rgba(0,0,0,0.1)', overflow: 'hidden', border: '1px solid #e8e8e8' }}>
         <Row style={{ height: '100%' }}>
           <Col span={12} style={{ position: 'relative', background: '#fafafa' }}>

--- a/frontend/src/components/GridCard.js
+++ b/frontend/src/components/GridCard.js
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
-import { Card, Tag, Typography, Button } from 'antd';
+import { Card, Tag, Typography, Button, message } from 'antd';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
-import { DownloadOutlined, StarFilled } from '@ant-design/icons';
+import { DownloadOutlined, StarFilled, CopyOutlined } from '@ant-design/icons';
 import { getStoreColor } from '../config/storeColors';
 
 const { Paragraph, Title, Text } = Typography;
@@ -10,12 +10,23 @@ const GridCard = ({ product, onDownload, calculateSavings }) => {
   const cardRef = useRef(null);
   return (
     <div style={{ position: 'relative', height: '100%' }}>
-      <Button
-        className="download-button"
-        icon={<DownloadOutlined />}
-        onClick={(e) => { e.preventDefault(); e.stopPropagation(); onDownload(cardRef); }}
-        style={{ position: 'absolute', top: '12px', right: '-40px', zIndex: 2 }}
-      />
+      <div style={{ position: 'absolute', top: '12px', right: '12px', display: 'flex', gap: '8px', zIndex: 2 }}>
+        <Button
+          className="action-button copy-button"
+          icon={<CopyOutlined />}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            navigator.clipboard.writeText(product.title);
+            message.success('Copied title');
+          }}
+        />
+        <Button
+          className="action-button download-button"
+          icon={<DownloadOutlined />}
+          onClick={(e) => { e.preventDefault(); e.stopPropagation(); onDownload(cardRef); }}
+        />
+      </div>
       <div ref={cardRef} style={{ height: '100%' }}>
         <a href={product.product_url} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none', height: '100%', display: 'block' }}>
           <Card
@@ -31,7 +42,7 @@ const GridCard = ({ product, onDownload, calculateSavings }) => {
                 </Tag>
                 <Tag
                   color="#f5222d"
-                  style={{ position: 'absolute', top: '12px', right: '12px', borderRadius: '9999px', fontSize: '10px', fontWeight: 'bold', zIndex: 1 }}
+                  style={{ position: 'absolute', top: '12px', right: '48px', borderRadius: '9999px', fontSize: '10px', fontWeight: 'bold', zIndex: 1 }}
                 >
                   {product.discount}
                 </Tag>


### PR DESCRIPTION
## Summary
- reposition download buttons to avoid overlap
- add copy title icon for convenience
- hide action buttons during downloads

## Testing
- `npm test -- --watch=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68badcdc65d8832a9623b1502a55c3a4