### PR TITLE
Position FacebookCard action buttons below the title

### DIFF
--- a/frontend/src/components/FacebookCard.js
+++ b/frontend/src/components/FacebookCard.js
@@ -10,7 +10,7 @@ const FacebookCard = ({ product, onDownload, calculateSavings }) => {
   const cardRef = useRef(null);
   return (
     <div style={{ position: 'relative' }}>
-      <div style={{ position: 'absolute', top: '24px', right: '24px', display: 'flex', gap: '8px', zIndex: 2 }}>
+      <div style={{ position: 'absolute', bottom: '24px', right: '24px', display: 'flex', gap: '8px', zIndex: 2 }}>
         <Button
           className="action-button copy-button"
           icon={<CopyOutlined />}


### PR DESCRIPTION
## Summary
- Move copy/download button container to the bottom-right of the card so it doesn't overlap the title or tags.

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baffcf8038832ab9d76be09d49619e