### PR TITLE
Use left joins for deals and verify inserted records

### DIFF
--- a/backend/test_database.py
+++ b/backend/test_database.py
@@ -23,7 +23,21 @@ def test_insert_deals_commits_once_and_closes_connection():
 
     mock_conn = MagicMock()
     mock_cursor = MagicMock()
-    mock_cursor.fetchone.return_value = (1,)
+    mock_cursor.fetchone.side_effect = [
+        (1,),
+        (
+            "Item",
+            "10",
+            "20",
+            "50%",
+            "img",
+            "url",
+            1,
+            "mi",
+            "4",
+            "100",
+        ),
+    ]
     mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
     mock_conn.__enter__.return_value = mock_conn
 


### PR DESCRIPTION
## Summary
- Use LEFT JOIN with merchants when fetching deals
- Validate inserted deals by returning the row and logging mismatched fields
- Adapt database tests for new insert behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb0aeadae0832a8417659fe07a1d1c