### PR TITLE
Clear deals table before inserting new records

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -62,6 +62,8 @@ def insert_deals(deals_data):
     _ensure_database_url()
     with psycopg2.connect(DATABASE_URL) as conn, conn.cursor() as cur:
         create_tables(cur)
+        # Clear existing deals while keeping merchants intact
+        cur.execute("TRUNCATE TABLE deals RESTART IDENTITY CASCADE;")
 
         for deal in deals_data["products"]:
             try:

--- a/backend/test_database.py
+++ b/backend/test_database.py
@@ -51,6 +51,9 @@ def test_insert_deals_commits_once_and_closes_connection():
         db.insert_deals(deals_data)
 
     mock_create_tables.assert_called_once()
+    mock_cursor.execute.assert_any_call(
+        "TRUNCATE TABLE deals RESTART IDENTITY CASCADE;"
+    )
     mock_conn.commit.assert_called_once()
     mock_conn.__exit__.assert_called_once()
     mock_conn.cursor.return_value.__exit__.assert_called_once()


### PR DESCRIPTION
## Summary
- Truncate `deals` table at the start of `insert_deals` to reset IDs and remove stale rows while leaving `merchants` untouched
- Add unit test to verify the truncation call occurs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb0ba04df4832a8b2873b9dcef1300