### PR TITLE
refactor: move App inline styles to CSS module

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -22,6 +22,7 @@ import FacebookCard from './components/FacebookCard';
 import PaginationControls from './components/PaginationControls';
 import useDeals from './hooks/useDeals';
 import useMerchants from './hooks/useMerchants';
+import styles from './App.module.css';
 
 const { Content, Footer } = Layout;
 const { Text } = Typography;
@@ -95,7 +96,7 @@ const App = () => {
   const renderContent = () => {
     if (loading) {
       return (
-        <div className="loading-spinner-container" style={{ textAlign: 'center', padding: '50px' }}>
+        <div className={styles.loadingSpinnerContainer}>
           <Spin size="large" tip="Loading Deals..." />
         </div>
       );
@@ -111,7 +112,7 @@ const App = () => {
 
     if (viewMode === 'facebook') {
       return (
-        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '32px' }}>
+        <div className={styles.facebookContainer}>
           {deals.map((deal, index) => (
             <FacebookCard
               product={deal}
@@ -144,23 +145,23 @@ const App = () => {
       <Route
         path="/"
         element={
-          <Layout style={{ minHeight: '100vh' }}>
+          <Layout className={styles.layout}>
             {contextHolder}
             <AppHeader
               totalProducts={totalProducts}
               loading={loading}
               onRefresh={() => fetchDeals(1, selectedMerchant)}
             />
-            <Content style={{ padding: '24px' }}>
+            <Content className={styles.content}>
               {lastUpdated && (
-                <Text type="secondary" style={{ textAlign: 'center', display: 'block', marginBottom: '1rem' }}>
+                <Text type="secondary" className={styles.lastUpdated}>
                   Last Updated: {lastUpdated}
                 </Text>
               )}
               {isScraping && (
-                <Alert message="Scraping in progress..." type="info" showIcon style={{ marginBottom: '1rem' }} />
+                <Alert message="Scraping in progress..." type="info" showIcon className={styles.scrapingAlert} />
               )}
-              <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '24px' }}>
+              <div className={styles.viewModeContainer}>
                 <Space>
                   <Button
                     type={viewMode === 'facebook' ? 'primary' : 'default'}
@@ -176,15 +177,7 @@ const App = () => {
                   </Button>
                 </Space>
               </div>
-              <div
-                style={{
-                  background: '#fff',
-                  padding: '16px',
-                  borderRadius: '8px',
-                  marginBottom: '24px',
-                  textAlign: 'center',
-                }}
-              >
+              <div className={styles.filterContainer}>
                 <Text strong>Filter by Merchant:</Text>
                 <Space size={[0, 8]} wrap>
                   {merchants.map((merchant) => (
@@ -192,14 +185,16 @@ const App = () => {
                       key={merchant}
                       checked={selectedMerchant === merchant}
                       onChange={() => handleMerchantSelect(merchant)}
-                      style={{ fontSize: '14px', padding: '6px 12px', margin: '4px' }}
+                      className={`${styles.tag} ${
+                        selectedMerchant === merchant ? styles.tagChecked : ''
+                      }`}
                     >
                       {merchant}
                     </Tag.CheckableTag>
                   ))}
                 </Space>
               </div>
-              <div className="card-list-container" style={{ padding: 24, minHeight: 308, borderRadius: '8px' }}>
+              <div className={styles.cardListContainer}>
                 {renderContent()}
               </div>
               <PaginationControls
@@ -209,7 +204,7 @@ const App = () => {
                 onPageChange={handlePageChange}
               />
             </Content>
-            <Footer style={{ textAlign: 'center' }}>
+            <Footer className={styles.footer}>
               PriceZA Scraper ©2025 Created with Gemini
             </Footer>
           </Layout>

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -1,0 +1,70 @@
+.layout {
+  min-height: 100vh;
+}
+
+.content {
+  padding: 24px;
+}
+
+.loadingSpinnerContainer {
+  text-align: center;
+  padding: 50px;
+}
+
+.facebookContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+
+.lastUpdated {
+  text-align: center;
+  display: block;
+  margin-bottom: 1rem;
+}
+
+.scrapingAlert {
+  margin-bottom: 1rem;
+}
+
+.viewModeContainer {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 24px;
+}
+
+.filterContainer {
+  background: #e9ecef;
+  padding: 16px;
+  border-radius: 8px;
+  margin-bottom: 24px;
+  text-align: center;
+  border: 1px solid #34495e;
+  color: #34495e;
+}
+
+.tag {
+  font-size: 14px;
+  padding: 6px 12px;
+  margin: 4px;
+  border: 1px solid #34495e;
+  color: #34495e;
+  background: #e9ecef;
+  transition: all 0.3s;
+}
+
+.tagChecked {
+  background: #34495e;
+  color: #e9ecef;
+}
+
+.cardListContainer {
+  padding: 24px;
+  min-height: 308px;
+  border-radius: 8px;
+}
+
+.footer {
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- replace App inline styles with a dedicated CSS module
- theme merchant filter tags with site palette and Ant Design styling

## Testing
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bb0d352820832a8c9f965545fc74a3