### PR TITLE
Order deal listings by id instead of scrape time

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -198,7 +198,7 @@ def get_deals_from_db(
         if merchant:
             select_query += " WHERE LOWER(m.name) = LOWER(%s)"
 
-        select_query += " ORDER BY d.scraped_at DESC LIMIT %s OFFSET %s"
+        select_query += " ORDER BY d.id DESC LIMIT %s OFFSET %s"
         params.extend([page_size, offset])
 
         cur.execute(select_query, tuple(params))


### PR DESCRIPTION
## Summary
- Use `d.id` to sort deals so newest records appear first
- Keep existing pagination and merchant filter when fetching deals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb13a231cc832ab19b25fba0f03ad5