### PR TITLE
feat: centralize Ant Design theme tokens

### DIFF
--- a/frontend/src/components/FacebookCard.js
+++ b/frontend/src/components/FacebookCard.js
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { Row, Col, Button, Tag, Typography, Space, message } from 'antd';
+import { Row, Col, Button, Tag, Typography, Space, message, theme } from 'antd';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
 import { DownloadOutlined, FacebookOutlined, ShoppingCartOutlined, StarFilled, CopyOutlined } from '@ant-design/icons';
 import { getStoreColor } from '../config/storeColors';
@@ -8,6 +8,7 @@ const { Title, Text } = Typography;
 
 const FacebookCard = ({ product, onDownload, calculateSavings }) => {
   const cardRef = useRef(null);
+  const { token } = theme.useToken();
   return (
     <div style={{ position: 'relative' }}>
       <div style={{ position: 'absolute', bottom: '24px', right: '24px', display: 'flex', gap: '8px', zIndex: 2 }}>
@@ -25,13 +26,26 @@ const FacebookCard = ({ product, onDownload, calculateSavings }) => {
           onClick={() => onDownload(cardRef)}
         />
       </div>
-      <div ref={cardRef} style={{ width: '1200px', height: '630px', background: 'white', borderRadius: '24px', boxShadow: '0 10px 30px rgba(0,0,0,0.1)', overflow: 'hidden', border: '1px solid #e8e8e8' }}>
+      <div
+        ref={cardRef}
+        style={{
+          width: '1200px',
+          height: '630px',
+          background: 'white',
+          borderRadius: token.borderRadius * 1.5,
+          boxShadow: '0 10px 30px rgba(0,0,0,0.1)',
+          overflow: 'hidden'
+        }}
+      >
         <Row style={{ height: '100%' }}>
           <Col span={12} style={{ position: 'relative', background: '#fafafa' }}>
             <Tag color={getStoreColor(product.merchant)} style={{ position: 'absolute', top: '24px', left: '24px', padding: '8px 16px', borderRadius: '16px', fontSize: '16px', fontWeight: 'bold', zIndex: 1 }}>
               {product.merchant}
             </Tag>
-            <Tag color="#f5222d" style={{ position: 'absolute', top: '24px', right: '24px', padding: '8px 16px', borderRadius: '16px', fontSize: '16px', fontWeight: 'bold', zIndex: 1 }}>
+            <Tag
+              color={token.colorPrimary}
+              style={{ position: 'absolute', top: '24px', right: '24px', padding: '8px 16px', borderRadius: '16px', fontSize: '16px', fontWeight: 'bold', zIndex: 1 }}
+            >
               {product.discount}
             </Tag>
             <LazyLoadImage
@@ -64,11 +78,14 @@ const FacebookCard = ({ product, onDownload, calculateSavings }) => {
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-                <Title level={1} style={{ margin: 0, color: '#f5222d' }}>฿{product.price}</Title>
+                <Title level={1} style={{ margin: 0, color: token.colorPrimary }}>฿{product.price}</Title>
               </div>
               <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
                 <Text delete style={{ fontSize: '24px' }}>฿{product.original_price}</Text>
-                <Tag color="#fff1f0" style={{ color: '#f5222d', padding: '8px 12px', borderRadius: '8px', fontSize: '18px', fontWeight: 'bold' }}>
+                <Tag
+                  color={token.colorPrimaryBg}
+                  style={{ color: token.colorPrimary, padding: '8px 12px', borderRadius: '8px', fontSize: '18px', fontWeight: 'bold' }}
+                >
                   ประหยัด ฿{calculateSavings(product.original_price, product.price)}
                 </Tag>
               </div>

--- a/frontend/src/components/GridCard.js
+++ b/frontend/src/components/GridCard.js
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { Card, Tag, Typography, Button, message } from 'antd';
+import { Card, Tag, Typography, Button, message, theme } from 'antd';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
 import { DownloadOutlined, StarFilled, CopyOutlined } from '@ant-design/icons';
 import { getStoreColor } from '../config/storeColors';
@@ -8,6 +8,7 @@ const { Paragraph, Title, Text } = Typography;
 
 const GridCard = ({ product, onDownload, calculateSavings }) => {
   const cardRef = useRef(null);
+  const { token } = theme.useToken();
   return (
     <div style={{ position: 'relative', height: '100%' }}>
       <div
@@ -41,7 +42,7 @@ const GridCard = ({ product, onDownload, calculateSavings }) => {
         <a href={product.product_url} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none', height: '100%', display: 'block' }}>
           <Card
             hoverable
-            style={{ borderRadius: '16px', overflow: 'hidden', border: '2px solid #f0f0f0', height: '100%' }}
+            style={{ overflow: 'hidden', height: '100%' }}
             cover={
               <div style={{ position: 'relative', height: '180px', background: '#f5f5f5' }}>
                 <div
@@ -62,7 +63,7 @@ const GridCard = ({ product, onDownload, calculateSavings }) => {
                     {product.merchant}
                   </Tag>
                   <Tag
-                    color="#f5222d"
+                    color={token.colorPrimary}
                     style={{ borderRadius: '9999px', fontSize: '10px', fontWeight: 'bold' }}
                   >
                     {product.discount}
@@ -101,15 +102,27 @@ const GridCard = ({ product, onDownload, calculateSavings }) => {
               )}
               <div style={{ margin: '12px 0' }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                  <Title level={5} style={{ margin: 0, color: '#f5222d' }}>฿{product.price}</Title>
-                  <Tag color="#fff1f0" style={{ color: '#f5222d', fontSize: '10px', fontWeight: 'semibold', borderRadius: '4px' }}>
+                  <Title level={5} style={{ margin: 0, color: token.colorPrimary }}>฿{product.price}</Title>
+                  <Tag
+                    color={token.colorPrimaryBg}
+                    style={{ color: token.colorPrimary, fontSize: '10px', fontWeight: 'semibold', borderRadius: '4px' }}
+                  >
                     ประหยัด ฿{calculateSavings(product.original_price, product.price)}
                   </Tag>
                 </div>
                 <Text delete type="secondary" style={{ fontSize: '12px' }}>฿{product.original_price}</Text>
               </div>
             </div>
-            <div style={{ background: 'linear-gradient(to right, #4A90E2, #9013FE)', color: 'white', padding: '8px', textAlign: 'center', borderRadius: '8px', marginTop: 'auto' }}>
+            <div
+              style={{
+                background: 'linear-gradient(to right, #4A90E2, #9013FE)',
+                color: 'white',
+                padding: '8px',
+                textAlign: 'center',
+                borderRadius: token.borderRadius,
+                marginTop: 'auto'
+              }}
+            >
               <Text style={{ color: 'white', fontSize: '12px', fontWeight: 'medium' }}>
                 โปรดีบอกต่อ Prod
               </Text>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,8 +5,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #e9ecef; /* A darker grey background */
-  color: #34495e; /* Darker text for better contrast */
+  background-color: #f5f5f5; /* Light neutral background to highlight cards */
+  color: #333333; /* Dark text for better contrast */
 }
 
 code {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { ConfigProvider } from 'antd';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
@@ -8,9 +9,18 @@ import reportWebVitals from './reportWebVitals';
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <ConfigProvider
+      theme={{
+        token: {
+          colorPrimary: '#f5222d',
+          borderRadius: 16,
+        },
+      }}
+    >
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ConfigProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- wrap App with Ant Design ConfigProvider
- reference global theme tokens in card components
- lighten page background to match new theme

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bb17b7a9bc832a96cdf21e6c291ea4