### PR TITLE
Remove obsolete version line from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:13


### PR DESCRIPTION
## Summary
- remove deprecated version line from docker-compose

## Testing
- `pytest`
- `docker compose up -d --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1f8411ac832aad415f29b450a647